### PR TITLE
Added missing includes, causing compilation errors

### DIFF
--- a/src/atlas/physics/jolt-cpp/jolt_collision.cpp
+++ b/src/atlas/physics/jolt-cpp/jolt_collision.cpp
@@ -2,6 +2,9 @@
 #include <physics/jolt-cpp/jolt_collision_manager.hpp>
 #include <physics/jolt-cpp/jolt_collision.hpp>
 
+#include <core/scene/world.hpp>
+#include <core/system_framework/system_registry.hpp>
+
 namespace atlas::physics {
 
     jolt_collision::jolt_collision() {

--- a/src/atlas/physics/jolt-cpp/jolt_contact_listener.cpp
+++ b/src/atlas/physics/jolt-cpp/jolt_contact_listener.cpp
@@ -7,6 +7,9 @@
 
 #include <flecs.h>
 
+#include <core/scene/world.hpp>
+#include <core/system_framework/system_registry.hpp>
+
 namespace atlas::physics {
 
     ref<jolt_collision_manager> m_manager;

--- a/src/atlas/physics/physics_3d/jolt/jolt_context.cpp
+++ b/src/atlas/physics/physics_3d/jolt/jolt_context.cpp
@@ -5,6 +5,8 @@
 #include <physics/types.hpp>
 #include <scene/scene.hpp>
 #include <physics/physics_3d/jolt/jolt_helper.hpp>
+#include <core/scene/world.hpp>
+#include <core/system_framework/system_registry.hpp>
 
 namespace atlas::physics {
 


### PR DESCRIPTION
There was a compilation error that was causing errors due to missing includes in the three of the specific jolt files. I just added the missing includes into those files.