### PR TITLE
Fixed Window Resizing Bug

### DIFF
--- a/src/atlas/core/application.cpp
+++ b/src/atlas/core/application.cpp
@@ -99,7 +99,7 @@ namespace atlas {
           .each([&](flecs::pair<tag::editor, projection_view> p_pair,
                     transform& p_transform,
                     perspective_camera& p_camera) {
-              float aspect_ratio = application::aspect_ratio();
+              float aspect_ratio = m_window->aspect_ratio();
               if (!p_camera.is_active) {
                   return;
               }

--- a/src/atlas/drivers/vulkan-cpp/vk_window.cpp
+++ b/src/atlas/drivers/vulkan-cpp/vk_window.cpp
@@ -65,7 +65,7 @@ namespace atlas::vk {
     }
 
     window_settings vk_window::settings() const {
-        return m_settings;
+        return m_swapchain.settings();
     }
 
     uint32_t vk_window::read_acquired_next_frame() {


### PR DESCRIPTION
# Window Resize Bug

When resizing the window, the viewport was stretched. This happened due to the aspect ratio not being modified everytime the window was being resized.

# Fix

I did a simple fix, which was passing in the swapchain window settings to ensure the window always passes the update window settings.